### PR TITLE
fix: define top_100_clients alias so script runs headless

### DIFF
--- a/mothership_complete_api_analysis.R
+++ b/mothership_complete_api_analysis.R
@@ -315,6 +315,7 @@ if(nrow(comms.all) > 0){
     write.csv(top_clients,file='mothership_top_clients.csv', row.names=FALSE)
 
     # Use committee IDs from the analysis for the next steps
+    top_100_clients <- top_clients  # alias needed because object referenced below
     cmte_ids <- unique(na.omit(top_100_clients$CMTE_ID))
 } else {
     cmte_ids <- unique(na.omit(mothership_payments$committee_id))


### PR DESCRIPTION
The script referenced `top_100_clients` before it was created, causing:
> Error: object 'top_100_clients' not found

when run non-interactively. This alias lets the file execute start-to-finish without relying on objects in the RStudio session.