### PR TITLE
add IE tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+archive/
+script_output.log
+.env


### PR DESCRIPTION
The current analysis excludes Schedule E and therefore undercounts $$ that actually benefited candidates by an order of magnitude. Re-running the same FEC queries with the missing endpoint and proper de-duplication shows $134M, not $11M, reached campaigns or party committees, a 20 % efficiency rate, not 1.6 %.

** This is not a defense of Mothership or their practices, in fact the opposite, I hope this addresses the main flaw in the original analysis. ** 